### PR TITLE
Add guides folder, setup.md with Mac setup

### DIFF
--- a/guides/SETUP.md
+++ b/guides/SETUP.md
@@ -1,0 +1,37 @@
+# SETUP.md
+
+## Prerequisites
+
+Please make sure to share your email with Chanu on Discord (@Chanukya) so you can receive an email invite to the Databricks workspace.
+
+## Mac
+
+Once you've joined the Databricks workspace, you can set up the Databricks CLI with these steps:
+
+1. Install Homebrew (offical documentation [here](https://brew.sh/)).
+2. Run
+
+    ```bash
+    brew tap databricks/tap
+    brew install databricks
+    ```
+
+to install the Databricks CLI at version >=0.269.0.
+3. Run
+
+```bash
+databricks auth login
+```
+
+4. When prompted for your Databricks profile name, enter the email address you used to join the Databricks workspace.
+5. When prompted for your Databricks host:
+    a. Go to the Databricks workspace.
+    b. Click on `Compute` in the left sidebar.
+    c. Click on `Serverless Starter Warehouse` under the `SQL Warehouse` tab.
+    d. Click on the `Connection details` tab.
+    e. Copy the `OAuth URL` value at the bottom of the tab.
+    f. Enter this value as the Databricks host.
+
+You should now see `Profile <email address> was successfully saved` in the command line.
+
+## Windows


### PR DESCRIPTION
This PR creates a `guides` folder at the root level of the repo and adds `SETUP.md` to the folder with Databricks CLI installation instructions for Mac.